### PR TITLE
Use Android attr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,15 @@
+## 2.1.1 - 2018/07/02
+
+### Bug fixes
+
+- Fix crash retrieving attr. Primary and accent colors are now retrieved from the system attrs.
+
+
 ## 2.1.0 - 2018/06/02
 
 ### Bug fixes/Behavior changes
 
-- use Attributes to obtain `colorPrimary` and `colorAccent`, so that we don't need to declare color value named `colorPrimary` or `colorAccent` [#43](https://github.com/yshrsmz/LicenseAdapter/issues/43)
+- Use Attributes to obtain `colorPrimary` and `colorAccent`, so that we don't need to declare color value named `colorPrimary` or `colorAccent` [#43](https://github.com/yshrsmz/LicenseAdapter/issues/43)
 
 
 ## 2.0.2 - 2017/12/14

--- a/library/src/main/java/net/yslibrary/licenseadapter/internal/LibraryViewHolder.java
+++ b/library/src/main/java/net/yslibrary/licenseadapter/internal/LibraryViewHolder.java
@@ -25,7 +25,7 @@ public final class LibraryViewHolder extends ViewHolderBase implements View.OnCl
     author = itemView.findViewById(R.id.author);
     expand = itemView.findViewById(R.id.expand);
 
-    colorAccent = Utils.getIntValueFromAttribute(itemView.getContext(), R.attr.colorAccent);
+    colorAccent = Utils.getIntValueFromAttribute(itemView.getContext(), android.R.attr.colorAccent);
     normalTextColor = name.getCurrentTextColor();
 
     itemView.setOnClickListener(this);

--- a/library/src/main/java/net/yslibrary/licenseadapter/internal/ViewHolderBase.java
+++ b/library/src/main/java/net/yslibrary/licenseadapter/internal/ViewHolderBase.java
@@ -5,7 +5,6 @@ import android.support.annotation.NonNull;
 import android.support.customtabs.CustomTabsIntent;
 import android.support.v7.widget.RecyclerView;
 import android.view.View;
-import net.yslibrary.licenseadapter.R;
 
 public abstract class ViewHolderBase extends RecyclerView.ViewHolder {
   private final int colorPrimary;
@@ -13,7 +12,7 @@ public abstract class ViewHolderBase extends RecyclerView.ViewHolder {
   public ViewHolderBase(View itemView) {
     super(itemView);
 
-    colorPrimary = Utils.getIntValueFromAttribute(itemView.getContext(), R.attr.colorPrimary);
+    colorPrimary = Utils.getIntValueFromAttribute(itemView.getContext(), android.R.attr.colorPrimary);
   }
 
   protected final void launchUri(Uri uri) {


### PR DESCRIPTION
Fixes this crash:

```
android.content.res.Resources$NotFoundException: Resource ID #0x7b020001 type #0x1 is not valid
        at android.content.res.Resources.getColor(Resources.java:967)
        at android.content.Context.getColor(Context.java:610)
        at android.support.v4.content.ContextCompat.getColor(ContextCompat.java:418)
        at net.yslibrary.licenseadapter.internal.ViewHolderBase.<init>(ViewHolderBase.java:16)
        at net.yslibrary.licenseadapter.internal.LibraryViewHolder.<init>(LibraryViewHolder.java:23)
        at net.yslibrary.licenseadapter.LicenseAdapter.onCreateViewHolder(LicenseAdapter.java:78)
        at net.yslibrary.licenseadapter.LicenseAdapter.onCreateViewHolder(LicenseAdapter.java:31)
        at android.support.v7.widget.RecyclerView$Adapter.createViewHolder(RecyclerView.java:6685)
        at android.support.v7.widget.RecyclerView$Recycler.tryGetViewHolderForPositionByDeadline(RecyclerView.java:5869)
        at android.support.v7.widget.RecyclerView$Recycler.getViewForPosition(RecyclerView.java:5752)
        at android.support.v7.widget.RecyclerView$Recycler.getViewForPosition(RecyclerView.java:5748)
        at android.support.v7.widget.LinearLayoutManager$LayoutState.next(LinearLayoutManager.java:2232)
        at android.support.v7.widget.LinearLayoutManager.layoutChunk(LinearLayoutManager.java:1559)
        at android.support.v7.widget.LinearLayoutManager.fill(LinearLayoutManager.java:1519)
        at android.support.v7.widget.LinearLayoutManager.onLayoutChildren(LinearLayoutManager.java:614)
        at android.support.v7.widget.RecyclerView.dispatchLayoutStep2(RecyclerView.java:3812)
        at android.support.v7.widget.RecyclerView.dispatchLayout(RecyclerView.java:3529)
        at android.support.v7.widget.RecyclerView.onLayout(RecyclerView.java:4082)
        at android.view.View.layout(View.java:20672)
        at android.view.ViewGroup.layout(ViewGroup.java:6194)
        at android.widget.FrameLayout.layoutChildren(FrameLayout.java:323)
        at android.widget.FrameLayout.onLayout(FrameLayout.java:261)
        at android.view.View.layout(View.java:20672)
        at android.view.ViewGroup.layout(ViewGroup.java:6194)
        at android.widget.FrameLayout.layoutChildren(FrameLayout.java:323)
        at android.widget.FrameLayout.onLayout(FrameLayout.java:261)
        at android.view.View.layout(View.java:20672)
        at android.view.ViewGroup.layout(ViewGroup.java:6194)
        at android.support.v7.widget.ActionBarOverlayLayout.onLayout(ActionBarOverlayLayout.java:443)
        at android.view.View.layout(View.java:20672)
        at android.view.ViewGroup.layout(ViewGroup.java:6194)
        at android.widget.FrameLayout.layoutChildren(FrameLayout.java:323)
        at android.widget.FrameLayout.onLayout(FrameLayout.java:261)
        at android.view.View.layout(View.java:20672)
        at android.view.ViewGroup.layout(ViewGroup.java:6194)
        at android.widget.LinearLayout.setChildFrame(LinearLayout.java:1812)
        at android.widget.LinearLayout.layoutVertical(LinearLayout.java:1656)
        at android.widget.LinearLayout.onLayout(LinearLayout.java:1565)
        at android.view.View.layout(View.java:20672)
        at android.view.ViewGroup.layout(ViewGroup.java:6194)
        at android.widget.FrameLayout.layoutChildren(FrameLayout.java:323)
        at android.widget.FrameLayout.onLayout(FrameLayout.java:261)
        at com.android.internal.policy.DecorView.onLayout(DecorView.java:753)
        at android.view.View.layout(View.java:20672)
        at android.view.ViewGroup.layout(ViewGroup.java:6194)
        at android.view.ViewRootImpl.performLayout(ViewRootImpl.java:2793)
        at android.view.ViewRootImpl.performTraversals(ViewRootImpl.java:2320)
        at android.view.ViewRootImpl.doTraversal(ViewRootImpl.java:1460)
        at android.view.ViewRootImpl$TraversalRunnable.run(ViewRootImpl.java:7184)
        at android.view.Choreographer$CallbackRecord.run(Choreographer.java:949)
        at android.view.Choreographer.doCallbacks(Choreographer.java:761)
        at android.view.Choreographer.doFrame(Choreographer.java:696)
        at android.view.Choreographer$FrameDisplayEventReceiver.run(Choreographer.java:935)
        at android.os.Handler.handleCallback(Handler.java:873)
        at android.os.Handler.dispatchMessage(Handler.java:99)
        at android.os.Looper.loop(Looper.java:193)
        at android.app.ActivityThread.main(ActivityThread.java:6669)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:493)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:858)
```