### PR TITLE
fix v2.1.2 buid error 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
   }
 
   dependencies {
-    classpath 'com.android.tools.build:gradle:3.1.2'
+    classpath 'com.android.tools.build:gradle:3.1.4'
 
     classpath 'com.github.ben-manes:gradle-versions-plugin:0.17.0'
     classpath 'com.novoda:bintray-release:0.8.1' // https://github.com/novoda/bintray-release

--- a/library/src/main/res/layout/library.xml
+++ b/library/src/main/res/layout/library.xml
@@ -41,7 +41,7 @@
     />
 
   <ImageView
-    android:id="@+id/expand"
+    android:id="@id/expand"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:contentDescription="@string/accessibility_expand"

--- a/library/src/main/res/values/ids.xml
+++ b/library/src/main/res/values/ids.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <item name="expand" type="id"/>
+</resources>


### PR DESCRIPTION
fix buidl error  …
AGPBI: {"kind":"error","text":"No resource found that matches the given name (at \u0027layout_constraintEnd_toStartOf\u0027 with value \u0027@id/expand\u0027).","sources":[{"file":"C:\\Users\\pradmin\\.gradle\\caches\\transforms-1\\files-1.1\\licenseadapter-2.1.2.aar\\d1fdceb0e304dcc0331ac3c80f873e9c\\res\\layout\\library.xml","position":{"startLine":21,"startColumn":40,"startOffset":1298,"endColumn":50,"endOffset":1308}}],"original":"","tool":"AAPT"}